### PR TITLE
Add configurable HTTP proxy

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -22,8 +22,8 @@ import (
 	"net/url"
 )
 
-func EdgeHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate) http.Handler {
-	proxy := SmartHTTPProxy(forwardingAddress, caList, clientCert)
+func EdgeHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) http.Handler {
+	proxy := SmartHTTPProxy(forwardingAddress, caList, clientCert, proxyForEdge)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxyURL := &url.URL{

--- a/http/smart_proxy.go
+++ b/http/smart_proxy.go
@@ -32,13 +32,13 @@ type SmartProxy struct {
 	wsHandler   http.Handler
 }
 
-func SmartHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate) *SmartProxy {
+func SmartHTTPProxy(forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) *SmartProxy {
 	proxyURL := &url.URL{
 		Scheme: "https",
 		Host:   forwardingAddress(""),
 	}
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-	proxy.Transport = EdgeTransport(caList, clientCert)
+	proxy.Transport = EdgeTransport(caList, clientCert, proxyForEdge)
 	proxy.FlushInterval = -1
 	director := proxy.Director
 	proxy.Director = func(req *http.Request) {

--- a/http/transport.go
+++ b/http/transport.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -55,8 +56,9 @@ func splitAddr(host string) (string, string, int, error) {
 	return hostParts[0], hostParts[1], port, nil
 }
 
-func EdgeTransport(caList *x509.CertPool, clientCert *tls.Certificate) *http.Transport {
+func EdgeTransport(caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(*http.Request) (*url.URL, error)) *http.Transport {
 	t := &http.Transport{
+		Proxy: proxyForEdge,
 		TLSClientConfig: &tls.Config{
 			RootCAs: caList,
 			GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {

--- a/server/edge_http_proxy.go
+++ b/server/edge_http_proxy.go
@@ -30,8 +30,8 @@ import (
 	fog_http "github.com/armPelionEdge/edge-proxy/http"
 )
 
-func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate) {
-	handler := fog_http.EdgeHTTPProxy(forwardingAddress, caList, clientCert)
+func RunEdgeHTTPProxyServer(ctx context.Context, listenAddr string, forwardingAddress func(string) string, caList *x509.CertPool, clientCert *tls.Certificate, proxyForEdge func(* http.Request) (*url.URL, error)) {
+	handler := fog_http.EdgeHTTPProxy(forwardingAddress, caList, clientCert, proxyForEdge)
 	listener, err := net.Listen("tcp", listenAddr)
 
 	if err != nil {


### PR DESCRIPTION
Added command line switch -extern-http-proxy-uri

This should not be confused with -proxy-uri.  edge-proxy is an http
proxy in and of itself.  This configuration is for when the gateway is
installed in a site which requires an http proxy for its outbound http
traffic.